### PR TITLE
remove default retry functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "bugs": "https://github.com/goodeggs/json-fetch/issues",
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
-    "object-assign": "^4.0.1",
-    "promise-retry": "^1.0.1"
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "babel": "^6.3.26",
@@ -33,7 +32,6 @@
     "babel-register": "^6.4.3",
     "chai": "~1.x.x",
     "es6-promise": "^3.0.2",
-    "isomorphic-fetch": "^2.2.0",
     "mocha": "~1.x.x",
     "nock": "^5.2.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import 'isomorphic-fetch';
-import promiseRetry from 'promise-retry';
 import objectAssign from 'object-assign';
 
-export default function jsonFetch(URL, fetchOptions = {}, MAX_RETRY_ATTEMPTS = 5) {
+export default function jsonFetch(URL, fetchOptions = {}) {
   let fetchOptionsClone = objectAssign({}, fetchOptions);
   const jsonHeaders = {
     'Accept': 'application/json',
@@ -16,11 +15,8 @@ export default function jsonFetch(URL, fetchOptions = {}, MAX_RETRY_ATTEMPTS = 5
     fetchOptionsClone.body = JSON.stringify(fetchOptions.body);
   } catch (err) {}
 
-  return promiseRetry((retry) => {
-    return fetch(URL, fetchOptionsClone).catch(retry);
-  }, {
-    retries: MAX_RETRY_ATTEMPTS
-  }).then((response) => {
+  return fetch(URL, fetchOptionsClone)
+  .then((response) => {
     const jsonFetchResponse = {
       status: response.status,
       statusText: response.statusText,


### PR DESCRIPTION
Remove default retry functionality as fail-fast is preferable:

- for fetches in response to user actions
- in tests

@dannynelson voted to just pull out the retry functionality entirely.