### PR TITLE
Handle non-200-level responses without throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 A wrapper around ES6 fetch to simplify interacting with JSON APIs.
 
-- resolve with json for 200-level responses
-- reject with an error for non 200-level responses
-- retry request for network errors
 - automatically JSON stringify request body
 - set JSON request headers
-- include request credentials
+- resolve with json for any response with the `Content-Type`: `application/json` header
+- include request credentials by default (can be overridden!)
+- configurable retry option for requests
 
 [![build status][travis-badge]][travis-link]
 [![npm version][npm-badge]][npm-link]

--- a/src/index.js
+++ b/src/index.js
@@ -47,17 +47,11 @@ export default function jsonFetch(URL, options = {}) {
       statusText: response.statusText,
       headers: response.headers
     };
-    if (200 <= response.status && response.status < 300) {
-      return response.json().then(function (json) {
-        return objectAssign({}, jsonFetchResponse, {body: json});
-      })
-    } else if (response.status === 404) {
-      return objectAssign({}, jsonFetchResponse, {body: undefined});
-    } else {
-      return response.text().then(function(text) {
-        const err = objectAssign(new Error(response.statusText), jsonFetchResponse, {body: text});
-        throw err;
-      });
+
+    if (response.headers.get('Content-Type') === 'application/json') {
+      return response.json().then((json) => objectAssign({}, jsonFetchResponse, {body: json}))
     }
+
+    return response.text().then((text) => objectAssign({}, jsonFetchResponse, {body: text}))
   });
 }


### PR DESCRIPTION
See #6 for more context. If you are making an HTTP request, don't throw unless there is a syntax error or a network connection error. If the server responds with a 404 or a 501 or anything else, the request succeeds and it is the responsibility of the client to interpret the value of `response.status` and react accordingly.