### PR TITLE
Add expectedStatuses option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,18 +33,24 @@ export default async function jsonFetch (requestUrl: string, requestOptions: Jso
 async function retryFetch (requestUrl: string, requestOptions: JsonFetchRequestOptions): Promise<Response> {
   const shouldRetry = requestOptions.shouldRetry || DEFAULT_SHOULD_RETRY;
   const retryOptions = Object.assign({}, DEFAULT_RETRY_OPTIONS, requestOptions.retry);
-  return promiseRetry(async (retry) => {
-    try {
-      const res = await fetch(requestUrl, requestOptions);
-      if (shouldRetry(res))
-        return retry();
-      return res;
-    } catch (err) {
-      if (shouldRetry(err))
-        return retry(err);
-      throw err;
-    }
-  }, retryOptions);
+  try {
+    const response = await promiseRetry(async (retry) => {
+      try {
+        const res = await fetch(requestUrl, requestOptions);
+        if (shouldRetry(res))
+          return retry();
+        return res;
+      } catch (err) {
+        if (shouldRetry(err))
+          return retry(err);
+        throw err;
+      }
+    }, retryOptions);
+    return response;
+  } catch (err) {
+    err.name = 'FetchNetworkError';
+    throw err;
+  }
 }
 
 async function createJsonFetchResponse (response: Response): Promise<JsonFetchResponse> {
@@ -94,7 +100,7 @@ class FetchUnexpectedStatusError extends Error {
   constructor (response: Object) {
     super();
     this.name = 'FetchUnexpectedStatusError';
-    this.message = `unexpected fetch response status ${response.status}`;
+    this.message = `Unexpected fetch response status ${response.status}`;
     this.response = response;
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,7 @@ describe('jsonFetch', async function () {
         await jsonFetch('http://www.test.com/products/1234');
       } catch (err) {
         errorThrown = true;
+        expect(err.name).to.deep.equal('FetchNetworkError');
         expect(err.message).to.deep.equal('Something is broken!');
       }
       expect(errorThrown).to.be.true();
@@ -86,7 +87,7 @@ describe('jsonFetch', async function () {
         await jsonFetch('http://www.test.com/products/1234', {expectedStatuses: [201]})
       } catch (err) {
         expect(err.name).to.equal('FetchUnexpectedStatusError');
-        expect(err.message).to.equal('unexpected fetch response status 400');
+        expect(err.message).to.equal('Unexpected fetch response status 400');
         expect(err.response).to.have.property('status', 400);
         expect(err.response).to.have.property('text', 'not found');
         return;


### PR DESCRIPTION
When `jsonFetch` receives a response status that is not one of the `expectedStatuses`, it will throw a `FetchUnexpectedStatusError` with the response metadata. These errors can be handled with a generic request error handler.

```js
function handleFetchError (err) {
  if (err.name === 'FetchUnexpectedStatusError' && err.response.status === 403)
    return showUserError('You are not allowed to view this page!');
  if (err.name === 'FetchNetworkError')
    return showUserError('Unable to connect to the server');
  return showUserError('Error!');
}

try {
  const response = await jsonFetch('https://test.com', {expectedStatuses: [200]});
} catch (err) {
  return handleFetchError(err)
}
```

Also throw a `FetchNetworkError` on network error (rather than `TypeError`), to simplify error handling.