### PR TITLE
Fix bug where FetchUnexpectedStatusError doesn't have a stack trace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,17 +65,11 @@ function isApplicationJson (headers: Headers): boolean {
 }
 
 function assertExpectedStatus <T: {+status: number}> (expectedStatuses: ?Array<number>, jsonFetchResponse: T): void {
-  if (Array.isArray(expectedStatuses) && !expectedStatuses.includes(jsonFetchResponse.status))
-    throw new FetchUnexpectedStatusError(jsonFetchResponse);
-}
-
-class FetchUnexpectedStatusError extends Error {
-  name: string;
-  response: JsonFetchResponse;
-  constructor (response: Object) {
-    super();
-    this.name = 'FetchUnexpectedStatusError';
-    this.message = `Unexpected fetch response status ${response.status}`;
-    this.response = response;
+  if (Array.isArray(expectedStatuses) && !expectedStatuses.includes(jsonFetchResponse.status)) {
+    const err = new Error(`Unexpected fetch response status ${jsonFetchResponse.status}`);
+    err.name = 'FetchUnexpectedStatusError';
+    // $FlowFixMe
+    err.response = jsonFetchResponse;
+    throw err;
   }
 }


### PR DESCRIPTION
Extending an Error in babel does not work as expected:
http://stackoverflow.com/questions/33870684/why-doesnt-instanceof-work-on-instances-of-error-subclasses-under-babel-node