### PR TITLE
Change FetchNetworkError to FetchError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ async function retryFetch (requestUrl: string, jsonFetchOptions: JsonFetchOption
     }, retryOptions);
     return response;
   } catch (err) {
-    err.name = 'FetchNetworkError';
+    err.name = 'FetchError';
     throw err;
   }
 }

--- a/src/test.js
+++ b/src/test.js
@@ -57,7 +57,7 @@ describe('jsonFetch', async function () {
         await jsonFetch('http://www.test.com/products/1234');
       } catch (err) {
         errorThrown = true;
-        expect(err.name).to.deep.equal('FetchNetworkError');
+        expect(err.name).to.deep.equal('FetchError');
         expect(err.message).to.deep.equal('Something is broken!');
       }
       expect(errorThrown).to.be.true();


### PR DESCRIPTION
Because this error can be thrown for non-network errors.

For instance, this error is thrown when you fetch with an invalid url or you fail to make the request due to CORS.