### PR TITLE
Don't include response headers in error details

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,10 @@ async function createJsonFetchResponse (response: Response): Promise<JsonFetchRe
 }
 
 function createErrorResponse (response: Response, responseText: string) {
+  // do not include headers as they potentially contain sensitive information
   return {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
     text: responseText,
   };
 }


### PR DESCRIPTION
as it may contain potentially sensitive information (eg. cookies)