### PR TITLE
Pass through timeout option (for node-fetch only)

### DIFF
--- a/src/get_request_options/index.js
+++ b/src/get_request_options/index.js
@@ -37,6 +37,7 @@ export default function getRequestOptions (jsonFetchOptions: JsonFetchOptions): 
     'redirect',
     'referrer',
     'referrerPolicy',
+    'timeout',
   ]);
 
   return Object.assign({}, pickedOptions, parsedOptions);

--- a/src/get_request_options/test.js
+++ b/src/get_request_options/test.js
@@ -30,4 +30,14 @@ describe('getRequestOptions', async function () {
     const actual = getRequestOptions({body: {hi: 'hello'}});
     expect(actual).to.deep.equal(expected);
   });
+
+  it('includes whitelisted options', function () {
+    const options = getRequestOptions({timeout: 123});
+    expect(options).to.have.property('timeout', 123);
+  });
+
+  it('excluded non-whitelisted options', function () {
+    const options = getRequestOptions({foo: 'bar'});
+    expect(options).not.to.contain.key('foo');
+  });
 });

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -15,6 +15,7 @@ export type JsonFetchOptions = {
   referrerPolicy?: ?ReferrerPolicyType,
   shouldRetry?: (responseOrError: Response | Error) => boolean,
   retry?: Object,
+  timeout?: number,
   expectedStatuses?: Array<number>,
 }
 


### PR DESCRIPTION
A `timeout` option is supported in `node-fetch`.

Not passing this through makes it hard to upgrade `json-fetch` above `5.1.2` for some codebases.