### PR TITLE
attach retryCount to any returned errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,13 +28,14 @@ async function retryFetch (requestUrl: string, jsonFetchOptions: JsonFetchOption
   const retryOptions = Object.assign({}, DEFAULT_RETRY_OPTIONS, jsonFetchOptions.retry);
   const requestOptions = getRequestOptions(jsonFetchOptions);
   try {
-    const response = await promiseRetry(async (throwRetryError) => {
+    const response = await promiseRetry(async (throwRetryError, retryCount) => {
       try {
         const res = await fetch(requestUrl, requestOptions);
         if (shouldRetry(res))
           throwRetryError();
         return res;
       } catch (err) {
+        err.retryCount = retryCount ? retryCount - 1 : 0;
         if (err.code !== 'EPROMISERETRY' && shouldRetry(err))
           throwRetryError(err);
         throw err;

--- a/src/test.js
+++ b/src/test.js
@@ -206,6 +206,26 @@ describe('jsonFetch', async function () {
       }
       throw new Error('Should have failed');
     });
+
+    it('adds the retryCount to the error', async function () {
+      fetch.restore(); // Don't double stub!
+      sinon.stub(global, 'fetch').returns(Promise.reject(new Error('ECONRST')));
+      try {
+        await jsonFetch('foo.bar', {
+          shouldRetry: () => true,
+          retry: {
+            retries: 5,
+            factor: 0,
+          },
+        });
+      } catch (err) {
+        expect(fetch.callCount).to.equal(6);
+        expect(err.message).to.equal('ECONRST');
+        expect(err.retryCount).to.equal(5);
+        return;
+      }
+      throw new Error('Should have failed');
+    });
   });
 
   describe('retriers', async function () {


### PR DESCRIPTION
So that we have more visibility into retries.