### PR TITLE
Separate responseOrError field to be 2 different fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changes since last deploy](https://github.com/goodeggs/json-fetch/compare/v8.0.0...master)
 
+# [9.0.8](https://github.com/goodeggs/json-fetch/compare/v9.0.8...v9.0.9)
+
+- Replaced `responseOrError` prop of `OnRequestEnd` by `error` and `status`
+
 # [9.0.8](https://github.com/goodeggs/json-fetch/compare/v9.0.3...v9.0.8)
 
 - Added `OnRequestStart` callback function

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ If given, `onRequestEnd` is called with:
   // ... all the original json-fetch options, plus:
   url: string;
   retryCount: number;
-  status: Response['status'];
+  status?: Response['status'];
+  error?: Error;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If given, `onRequestEnd` is called with:
   // ... all the original json-fetch options, plus:
   url: string;
   retryCount: number;
-  responseOrError: Response | Error;
+  status: Response['status'];
 }
 ```
 
@@ -139,8 +139,8 @@ const requestUrl = 'http://www.test.com/products/1234';
 await jsonFetch(requestUrl, {
   onRequestStart: ({url, timeout, retryCount}) =>
     console.log(`Requesting ${url} with timeout ${timeout}, attempt ${retryCount}`),
-  onRequestEnd: ({url, retryCount, responseOrError}) =>
-    console.log(`Requested ${url}, attempt ${retryCount}, got status ${responseOrError.status}`),
+  onRequestEnd: ({url, retryCount, status}) =>
+    console.log(`Requested ${url}, attempt ${retryCount}, got status ${status}`),
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-fetch",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "description": "A wrapper around ES6 fetch to simplify interacting with JSON APIs.",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -147,7 +147,29 @@ describe('jsonFetch', function () {
         url: 'http://www.test.com/products/1234',
         retryCount: 1,
         headers: {accept: 'application/json'},
+        status: 200,
       });
+    });
+
+    it('onRequestEnd returns error object when request fails', async function () {
+      sandbox.stub(global, 'fetch').callsFake(async function () {
+        throw new Error('Something is broken!');
+      });
+      const onRequestEnd = sandbox.stub();
+      try {
+        await jsonFetch('http://www.test.com/products/1234', {
+          onRequestEnd,
+        });
+      } catch {
+        expect(onRequestEnd).to.have.been.calledOnce();
+        expect(onRequestEnd).to.have.been.calledWithMatch({
+          error: {
+            request: {
+              url: 'http://www.test.com/products/1234',
+            },
+          },
+        });
+      }
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ async function retryFetch(
         const res = await fetch(requestUrl, requestOptions);
         if (shouldRetry(res)) throwRetryError(null);
         jsonFetchOptions.onRequestEnd?.({
-          status: res,
+          status: res.status,
           url: requestUrl,
           retryCount,
           ...requestOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface OnRequestOptions extends RequestInit {
 
 export interface OnRequestEndOptions extends OnRequestOptions {
   error?: Error;
-  status?: Response;
+  status?: Response['status'];
 }
 export interface JsonFetchOptions extends Omit<RequestInit, 'body'> {
   // node-fetch extensions (not available in browsers, i.e. whatwg-fetch) –

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ export interface OnRequestOptions extends RequestInit {
 }
 
 export interface OnRequestEndOptions extends OnRequestOptions {
-  responseOrError: Response | Error;
+  error?: Error;
+  status?: Response;
 }
 export interface JsonFetchOptions extends Omit<RequestInit, 'body'> {
   // node-fetch extensions (not available in browsers, i.e. whatwg-fetch) –
@@ -89,7 +90,7 @@ async function retryFetch(
         const res = await fetch(requestUrl, requestOptions);
         if (shouldRetry(res)) throwRetryError(null);
         jsonFetchOptions.onRequestEnd?.({
-          responseOrError: res,
+          status: res,
           url: requestUrl,
           retryCount,
           ...requestOptions,
@@ -98,7 +99,7 @@ async function retryFetch(
       } catch (err) {
         err.retryCount = retryCount - 1;
         jsonFetchOptions.onRequestEnd?.({
-          responseOrError: err,
+          error: err,
           url: requestUrl,
           retryCount,
           ...requestOptions,


### PR DESCRIPTION
Separate `responseOrError` into 2 different fields to have a more clear logger in **goodeggs-server** see [this comment](https://www.pivotaltracker.com/story/show/172844548/comments/229796750) for details